### PR TITLE
Add TutorialSearch to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Originally published as
 
 ### Websites
 * [Sheet2site](https://www.sheet2site.com/) - Turn your Google Sheets into a website
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/web-development/no-code-sites) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [Universe](https://apps.apple.com/us/app/universe-website-builder/id1211437633) - Make an awesome website from your phone
 * [Table2Site](https://table2site.com) - Generate websites from your Airtable base
 * [Squarespace](https://fr.squarespace.com/) - All-in-one platform to build a beautiful online e-commerce

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Originally published as
 
 ### Websites
 * [Sheet2site](https://www.sheet2site.com/) - Turn your Google Sheets into a website
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [Universe](https://apps.apple.com/us/app/universe-website-builder/id1211437633) - Make an awesome website from your phone
 * [Table2Site](https://table2site.com) - Generate websites from your Airtable base
 * [Squarespace](https://fr.squarespace.com/) - All-in-one platform to build a beautiful online e-commerce


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Websites* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/web-development/no-code-sites) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/web-development/no-code-sites) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.