### PR TITLE
Add TinyTools to Design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Originally published as
 ### Design
 * [Figma](https://www.figma.com/) - The first interface design tool with real-time collaboration
 * [unDraw](https://undraw.co/) - Free, open-source illustrations for everyone
+* [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based design utilities: OG image generator, favicon generator, AI background remover (runs locally), color palette generator. No signup required, open source.
 
 ### Design, Websites
 * [Webflow](https://webflow.com) - All-in-one web design platform


### PR DESCRIPTION
Hi! I'd like to add [TinyTools](https://tinytools-smoky.vercel.app/) to the **Design** section.

**TinyTools** is a free, open-source collection of browser-based design and utility tools — no code, no signup required:

- 🖼️ **OG image generator** — generate social preview images
- 🔖 **Favicon generator** — create favicons from text or image
- 🪄 **AI background remover** — runs entirely in the browser via WebAssembly (no upload)
- 🎨 **Color palette generator** — create harmonious color palettes
- Plus SEO, AI, and other utilities

All tools are free, browser-based, and open source. Happy to adjust the placement if there's a better section. Thanks for the great list!