### PR TITLE
Add LeadFinder to Scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Originally published as
 * [Octoparse](https://www.octoparse.com/) - Easy web scraping for everyone
 * [Parsehub](https://www.parsehub.com/) - Free web scraping
 * [Dataminer](https://data-miner.io/) - Easy to use web scraping
+* [LeadFinder](https://getleadscraper.com/) - Scrape local business leads from Google Maps by niche and city, export to CSV
 
 ### Video
 * [Loom](https://www.loom.com) - Seamless screen, mic, and camera recording for Chrome


### PR DESCRIPTION
Adds LeadFinder to the Scrapers section, alongside Octoparse, Parsehub and Dataminer. It's a no-code tool to pull local business leads (name, phone, website, address, rating) from Google Maps by niche and city, with CSV export. Has a free tier (5 leads per search, no signup), so it fits the no-code scrapers category here.